### PR TITLE
Add endpoints for fetching overall insights and logs within a time interval.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Insights service
 
-* This repository builds the opni-insights image which sets up an HTTP server that will return the breakdown of normal, suspicious and anomolous log messages by pod, namespace and workload between a specified time interval provided in nanoseconds.
+* This repository builds the opni-insights image which sets up an HTTP server that will return the breakdown of normal, suspicious and anomolous log messages by pod, namespace and workload between a specified time interval provided in nanoseconds. This server can also return the overall breakdown of normal, suspicious and anomalous log messages within a specified time interval by specifying a Get request to the overall_insights endpoint. It can also return the suspicious and anomalous log messages within a specified time interval by submitting a Get request to the logs endpoint.
 ### Setup RBAC permissions
 ```
 kubectl apply -f rbac.yaml
@@ -12,14 +12,14 @@ kubectl apply -f rbac.yaml
 kubectl port-forward svc/opni-insights-service 8000:80
 ```
 
-* Then, send a get request to the endpoint to fetch insight data on pods, namespaces, or workloads and specify the starting and ending time intervals to query that data from.
+* Then, send a get request to the endpoint to fetch insight data on pods, namespaces, workloads, logs or overall insights and specify the starting and ending time intervals to query that data from.
 
 * For example, to fetch the breakdown of log messages by workload between the timestamps 1631794584000 and 1631855784000, you can run this command to make a Get request to the workload endpoint:
 ```
 curl --location --request GET 'localhost:8000/workload?start_ts=1631794584000&end_ts=1631855784000' --header 'Content-Type: application/json'
 ```
 
-* To make a call to either the pod or namespace endpoint, simply replace workload in the curl command above with the respective term.
+* To make a call to either the pod, namespace, overall_insights or logs endpoint, simply replace workload in the curl command above with the respective term.
 
 * The resulting output will look something like this:
 ```

--- a/opni-insights-service/app/main.py
+++ b/opni-insights-service/app/main.py
@@ -273,6 +273,7 @@ def get_namespace_breakdown(start_ts, end_ts):
 
 
 def get_overall_breakdown(start_ts, end_ts):
+    # Get the overall breakdown of normal, suspicious and anomolous logs within start_ts and end_ts.
     overall_breakdown_dict = {"Normal": 0, "Suspicious": 0, "Anomaly": 0}
     for anomaly_level in overall_breakdown_dict:
         query_body = {
@@ -298,6 +299,10 @@ def get_overall_breakdown(start_ts, end_ts):
 
 
 def get_logs(start_ts, end_ts):
+    """
+    Get all logs and additional attributes such as the timestamp, anomaly_level, whether or not it is a control plane
+    log, pod name and namespace name.
+    """
     logs_dict = {"Logs": []}
     query_body = {
         "query": {

--- a/opni-insights-service/app/main.py
+++ b/opni-insights-service/app/main.py
@@ -2,8 +2,8 @@ import logging
 import os
 
 # Third Party
-from elasticsearch import Elasticsearch
-from elasticsearch.helpers import scan
+from elasticsearch import AsyncElasticsearch
+from elasticsearch.helpers import async_scan
 from fastapi import FastAPI
 from kubernetes import client, config
 
@@ -13,7 +13,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(messa
 ES_ENDPOINT = os.environ["ES_ENDPOINT"]
 ES_USERNAME = os.environ["ES_USERNAME"]
 ES_PASSWORD = os.environ["ES_PASSWORD"]
-es_instance = Elasticsearch(
+es_instance = AsyncElasticsearch(
     [ES_ENDPOINT],
     port=9200,
     http_compress=True,
@@ -27,7 +27,7 @@ core_api_instance = client.CoreV1Api()
 app_api_instance = client.AppsV1Api()
 
 
-def get_pod_breakdown(start_ts, end_ts):
+async def get_pod_breakdown(start_ts, end_ts):
     # Get the breakdown of normal, suspicious and anomolous logs by pod.
     pod_breakdown_dict = {"Pods": []}
     # Try accessing the list of all pods through the Kubernetesa API. If unsuccessful, return the pod_breakdown_dict object in its bare bone structure.
@@ -64,8 +64,8 @@ def get_pod_breakdown(start_ts, end_ts):
                         }
                     }
                 }
-                pod_dict["Insights"][insight] = es_instance.count(
-                    index="logs", body=query_body
+                pod_dict["Insights"][insight] = (
+                    await es_instance.count(index="logs", body=query_body)
                 )["count"]
             pod_breakdown_dict["Pods"].append(pod_dict)
         except Exception as e:
@@ -137,7 +137,7 @@ def get_workload_name(pod_metadata):
     return owner_name
 
 
-def get_workload_breakdown(start_ts, end_ts):
+async def get_workload_breakdown(start_ts, end_ts):
     # Get the breakdown of normal, suspicious and anomolous logs by workload.
     workload_breakdown_dict = {
         "ReplicaSet": {},
@@ -202,9 +202,9 @@ def get_workload_breakdown(start_ts, end_ts):
                 }
             }
             try:
-                workload_breakdown_dict[kind][workload_name][
-                    anomaly_level
-                ] += es_instance.count(index="logs", body=query_body)["count"]
+                workload_breakdown_dict[kind][workload_name][anomaly_level] += (
+                    await es_instance.count(index="logs", body=query_body)
+                )["count"]
             except Exception as e:
                 logging.error(f"Unable to query Elasticsearch. {e}")
                 continue
@@ -222,7 +222,7 @@ def get_workload_breakdown(start_ts, end_ts):
     return workload_breakdown_dict
 
 
-def get_namespace_breakdown(start_ts, end_ts):
+async def get_namespace_breakdown(start_ts, end_ts):
     # Get the breakdown of normal, suspicious and anomolous logs by namespace.
     namespace_breakdown_dict = {"Namespaces": []}
     # Try accessing the list of all pods through the Kubernetes API. If unsuccessful, return the namespace_breakdown_dict object in its bare bone structure.
@@ -262,8 +262,8 @@ def get_namespace_breakdown(start_ts, end_ts):
                         }
                     }
                 }
-                namespace_dict["Insights"][insight] = es_instance.count(
-                    index="logs", body=query_body
+                namespace_dict["Insights"][insight] = (
+                    await es_instance.count(index="logs", body=query_body)
                 )["count"]
             namespace_breakdown_dict["Namespaces"].append(namespace_dict)
         except Exception as e:
@@ -272,8 +272,8 @@ def get_namespace_breakdown(start_ts, end_ts):
     return namespace_breakdown_dict
 
 
-def get_overall_breakdown(start_ts, end_ts):
-    # Get the overall breakdown of normal, suspicious and anomolous logs within start_ts and end_ts.
+async def get_overall_breakdown(start_ts, end_ts):
+    # Get the overall breakdown of normal, suspicious and anomalous logs within start_ts and end_ts.
     overall_breakdown_dict = {"Normal": 0, "Suspicious": 0, "Anomaly": 0}
     for anomaly_level in overall_breakdown_dict:
         query_body = {
@@ -289,8 +289,8 @@ def get_overall_breakdown(start_ts, end_ts):
             }
         }
         try:
-            overall_breakdown_dict[anomaly_level] = es_instance.count(
-                index="logs", body=query_body
+            overall_breakdown_dict[anomaly_level] = (
+                await es_instance.count(index="logs", body=query_body)
             )["count"]
         except Exception as e:
             logging.error(f"Unable to access Elasticsearch data. {e}")
@@ -298,9 +298,9 @@ def get_overall_breakdown(start_ts, end_ts):
     return overall_breakdown_dict
 
 
-def get_logs(start_ts, end_ts):
+async def get_logs(start_ts, end_ts):
     """
-    Get all logs marked as Suspicious or Anomolous and additional attributes such as the timestamp, anomaly_level,
+    Get all logs marked as Suspicious or Anomoly and additional attributes such as the timestamp, anomaly_level,
     whether or not it is a control plane log, pod name and namespace name.
     """
     logs_dict = {"Logs": []}
@@ -322,8 +322,9 @@ def get_logs(start_ts, end_ts):
         "sort": [{"timestamp": {"order": "asc"}}],
     }
     try:
-        logs_within_time_interval = scan(es_instance, index="logs", query=query_body)
-        for each_result in logs_within_time_interval:
+        async for each_result in async_scan(
+            es_instance, index="logs", query=query_body
+        ):
             logs_dict["Logs"].append(each_result["_source"])
     except Exception as e:
         logging.error(f"Unable to access logs data. {e}")
@@ -339,7 +340,7 @@ async def index_pod(start_ts: int, end_ts: int):
         f"Received request to obtain pod insights between {start_ts} and {end_ts}"
     )
     try:
-        result = get_pod_breakdown(start_ts, end_ts)
+        result = await get_pod_breakdown(start_ts, end_ts)
         return result
     except Exception as e:
         # Bad Request
@@ -353,7 +354,7 @@ async def index_namespace(start_ts: int, end_ts: int):
         f"Received request to obtain namespace insights between {start_ts} and {end_ts}"
     )
     try:
-        result = get_namespace_breakdown(start_ts, end_ts)
+        result = await get_namespace_breakdown(start_ts, end_ts)
         return result
     except Exception as e:
         # Bad Request
@@ -367,7 +368,7 @@ async def index_workload(start_ts: int, end_ts: int):
         f"Received request to obtain workload insights between {start_ts} and {end_ts}"
     )
     try:
-        result = get_workload_breakdown(start_ts, end_ts)
+        result = await get_workload_breakdown(start_ts, end_ts)
         return result
     except Exception as e:
         # Bad Request
@@ -381,7 +382,7 @@ async def index_overall_breakdown(start_ts: int, end_ts: int):
         f"Received request to obtain all insights between {start_ts} and {end_ts}"
     )
     try:
-        result = get_overall_breakdown(start_ts, end_ts)
+        result = await get_overall_breakdown(start_ts, end_ts)
         return result
     except Exception as e:
         # Bad Request
@@ -393,7 +394,7 @@ async def index_logs(start_ts: int, end_ts: int):
     # This function handles get requests for fetching suspicious and anomalous logs between start_ts and end_ts
     logging.info(f"Received request to obtain all logs between {start_ts} and {end_ts}")
     try:
-        result = get_logs(start_ts, end_ts)
+        result = await get_logs(start_ts, end_ts)
         return result
     except Exception as e:
         # Bad Request

--- a/opni-insights-service/app/main.py
+++ b/opni-insights-service/app/main.py
@@ -390,7 +390,7 @@ async def index_overall_breakdown(start_ts: int, end_ts: int):
 
 @app.get("/logs")
 async def index_logs(start_ts: int, end_ts: int):
-    # This function handles get requests for fetching workload breakdown insights.
+    # This function handles get requests for fetching suspicious and anomalous logs between start_ts and end_ts
     logging.info(f"Received request to obtain all logs between {start_ts} and {end_ts}")
     try:
         result = get_logs(start_ts, end_ts)

--- a/opni-insights-service/app/main.py
+++ b/opni-insights-service/app/main.py
@@ -300,15 +300,16 @@ def get_overall_breakdown(start_ts, end_ts):
 
 def get_logs(start_ts, end_ts):
     """
-    Get all logs and additional attributes such as the timestamp, anomaly_level, whether or not it is a control plane
-    log, pod name and namespace name.
+    Get all logs marked as Suspicious or Anomolous and additional attributes such as the timestamp, anomaly_level,
+    whether or not it is a control plane log, pod name and namespace name.
     """
     logs_dict = {"Logs": []}
     query_body = {
         "query": {
             "bool": {
                 "filter": [{"range": {"timestamp": {"gte": start_ts, "lte": end_ts}}}],
-            }
+                "must_not": [{"match": {"anomaly_level": "Normal"}}],
+            },
         },
         "_source": [
             "timestamp",


### PR DESCRIPTION
This PR adds support for fetching logs within a start and end timestamp by implementing a logs endpoint for the HTTP server. It also adds support for fetching overall insights within a time interval by implementing a overall_insights endpoint for the HTTP server.