### PR TITLE
Add default environmental variables for peak detection algorithm parameters

### DIFF
--- a/opni-insights-service/app/main.py
+++ b/opni-insights-service/app/main.py
@@ -31,9 +31,9 @@ es_instance = AsyncElasticsearch(
     verify_certs=False,
     use_ssl=True,
 )
-WINDOW = int(os.environ["WINDOW"])
-THRESHOLD = float(os.environ["THRESHOLD"])
-INFLUENCE = float(os.environ["INFLUENCE"])
+WINDOW = int(os.getenv("WINDOW", "10"))
+THRESHOLD = float(os.getenv("THRESHOLD", "2.5"))
+INFLUENCE = float(os.getenv("INFLUENCE", "0.5"))
 
 config.load_incluster_config()
 configuration = client.Configuration()


### PR DESCRIPTION
This PR sets default environmental variables for the window, threshold and influence hyperparameters which are used in the Peak Detection algorithm. 