### PR TITLE
Refactor logs endpoint so it uses pagination to send at most 100 logs when receiving a Get request

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,19 @@ curl --location --request GET 'localhost:8000/overall_insights?start_ts=16317945
     "Suspicious": 1054,
     "Anomaly": 7341
 }
+
 ```
+* To fetch log messages between a starting and ending timestamp, you can run this command to make a Get request to the logs endpoint which will fetch 100 logs.
+```
+curl --location --request GET 'localhost:8000/logs?start_ts=1631794584000&end_ts=1631855784000' --header 'Content-Type: application/json'
+```
+In addition to returning 100 log messages as part of the current page, it will also return a scroll_id which can be used to access subsequent pages of log messages.
+
+* To fetch log messages between a starting and ending timestamp and with a specified scroll_id, you can run this command to make a Get request to the logs endpoint which will fetch the next 100 logs from the reference of the scroll_id.
+```
+curl --location --request GET 'localhost:8000/logs?start_ts=1631794584000&end_ts=1631855784000&scroll_id=SCROLL_ID' --header 'Content-Type: application/json'
+```
+
 
 
 

--- a/opni-insights-service/app/main.py
+++ b/opni-insights-service/app/main.py
@@ -477,29 +477,20 @@ async def get_logs(start_ts, end_ts, scroll_id):
     }
     scroll_value = "1m"
     # If scroll_id is provided, then use it to fetch the next 100 logs and return that in addition to the updated scroll_id as part of the logs_dict dictionary.
-    if scroll_id:
-        try:
+    try:
+        if scroll_id:
             current_page = await es_instance.scroll(scroll_id=scroll_id, scroll=scroll_value)
-            result_hits = current_page["hits"]["hits"]
-            logs_dict["scroll_id"] = current_page["_scroll_id"]
-            for each_hit in result_hits:
-                logs_dict["Logs"].append(each_hit["_source"])
-            return logs_dict
-        except Exception as e:
-            logging.error(f"Unable to access Elasticsearch logs index. {e}")
-            return logs_dict
-    else:
-        #If scroll_id is None, use the search function to fetch 100 logs and send back the scroll_id as a key in the log_dict dictionary.
-        try:
+        else:
             current_page = await es_instance.search(index="logs",body=query_body, scroll=scroll_value, size=100)
-            logs_dict["scroll_id"] = current_page["_scroll_id"]
-            result_hits = current_page["hits"]["hits"]
-            for each_hit in result_hits:
-                logs_dict["Logs"].append(each_hit["_source"])
-            return logs_dict
-        except Exception as e:
-            logging.error(f"Unable to access Elasticsearch logs index {e}")
-            return logs_dict
+        result_hits = current_page["hits"]["hits"]
+        logs_dict["scroll_id"] = current_page["_scroll_id"]
+        for each_hit in result_hits:
+            logs_dict["Logs"].append(each_hit["_source"])
+        return logs_dict
+    except Exception as e:
+        logging.error(f"Unable to access Elasticsearch logs index. {e}")
+        return logs_dict
+
 
 async def get_control_plane_components_breakdown(start_ts, end_ts):
     # Get the breakdown of normal, suspicious and anomolous logs by kubernetes control plane component.


### PR DESCRIPTION
This pull request refactors the logs endpoint by implementing pagination so anytime a Get request is sent to the endpoint, it will return at most 100 logs and also return the scroll_id which can be used to fetch the next page of 100 log messages. 