### PR TITLE
Update insights service to use composite aggregation queries.

### DIFF
--- a/opni-insights-service/app/endpoint_functions.py
+++ b/opni-insights-service/app/endpoint_functions.py
@@ -377,7 +377,7 @@ async def get_pod_aggregation(start_ts, end_ts):
         "aggs": {
             "bucket": {
                 "composite": {
-                    "size": 100,
+                    "size": 1000,
                     "sources": [{"namespace_name": {"terms": {"field":"kubernetes.namespace_name.keyword"}}}, {"pod_name": {"terms": {"field": "kubernetes.pod_name.keyword"}}}, {"anomaly_level": {"terms": {"field": "anomaly_level.keyword"}}}],
                 }
             }
@@ -579,7 +579,7 @@ async def get_namespace_breakdown(start_ts, end_ts):
         "aggs": {
             "bucket": {
                 "composite": {
-                    "size": 50,
+                    "size": 1000,
                     "sources": [{"namespace_name": {"terms": {"field":"kubernetes.namespace_name.keyword"}}}, {"anomaly_level": {"terms": {"field": "anomaly_level.keyword"}}}],
                 }
             }


### PR DESCRIPTION
This PR introduces composite aggregation queries for fetching the namespace and pod anomaly breakdown information. As a result of using composite aggregation, breakdowns for all pods will be returned whereas before only the top 10 pod results per namespace were being returned by the aggregation queries.